### PR TITLE
change api urls

### DIFF
--- a/demo/conduit_api.py
+++ b/demo/conduit_api.py
@@ -41,10 +41,14 @@ class ConduitAPI:
             'Authorization': f'Bearer {CONDUIT_API_TOKEN}',
         }
 
+        url = urljoin(CONDUIT_API_URL, path)
+
         if method == 'GET':
-            res = requests.request(method, urljoin(CONDUIT_API_URL, path), headers=headers, params=data)
+            res = requests.request(method, url, headers=headers, params=data)
+        elif method == 'POST':
+            res = requests.request(method, url, headers=headers, json=data)
         else:
-            res = requests.request(method, urljoin(CONDUIT_API_URL, path), headers=headers, json=data)
+            raise NotImplementedError()
 
         res.raise_for_status()
         return res.json()

--- a/demo/conduit_api.py
+++ b/demo/conduit_api.py
@@ -21,6 +21,11 @@ class ConduitAPI:
         return resp
 
     @classmethod
+    def get_company(cls, company_id: str, include_connections: bool = False) -> dict[str, Any]:
+        res = cls._request(f'link/company/{company_id}/', 'GET', {'include_connections': include_connections})
+        return res
+
+    @classmethod
     def create_company(cls, company_id: str) -> None:
         data = {
             'id': company_id,
@@ -35,7 +40,12 @@ class ConduitAPI:
             'accept': 'application/json',
             'Authorization': f'Bearer {CONDUIT_API_TOKEN}',
         }
-        res = requests.request(method, urljoin(CONDUIT_API_URL, path), headers=headers, json=data)
+
+        if method == 'GET':
+            res = requests.request(method, urljoin(CONDUIT_API_URL, path), headers=headers, params=data)
+        else:
+            res = requests.request(method, urljoin(CONDUIT_API_URL, path), headers=headers, json=data)
+
         res.raise_for_status()
         return res.json()
 
@@ -43,10 +53,6 @@ class ConduitAPI:
 class ConduitCompanyAPI:
     def __init__(self, token: str):
         self._token = token
-
-    def get_credentials(self) -> list[dict[str, Any]]:
-        resp = self._request('link/credentials/')
-        return resp
 
     def get_connect_url(self, integration_id: str) -> str:
         res = self._request(f'link/credentials/connect/{integration_id}/')

--- a/demo/conduit_api.py
+++ b/demo/conduit_api.py
@@ -45,10 +45,8 @@ class ConduitAPI:
 
         if method == 'GET':
             res = requests.request(method, url, headers=headers, params=data)
-        elif method == 'POST':
-            res = requests.request(method, url, headers=headers, json=data)
         else:
-            raise NotImplementedError()
+            res = requests.request(method, url, headers=headers, json=data)
 
         res.raise_for_status()
         return res.json()

--- a/demo/templates/company_info.html
+++ b/demo/templates/company_info.html
@@ -1,12 +1,12 @@
 {% extends 'base.html' %}
 {% block content %}
-    <h3>Connections for company with ID: {{ company_id }}</h3>
-    {% for integration in credentials %}
+    <h3>Connections for company with ID: {{ company.id }}</h3>
+    {% for integration in company.connections %}
         <div style="margin-left: 2em">
             <h4>
                 {{ integration.name }} ({{ integration.id }})
                 <a href="#"
-                   onclick="window.open('{% url 'connect' company_id=company_id integration_id=integration.id %}')"
+                   onclick="window.open('{% url 'connect' company_id=company.id integration_id=integration.id %}')"
                    style="padding: 0.3em 0.8em; border-radius: 0.3em; background: #183dfb; color: white; text-decoration: none;">
                     New Connection
                 </a>
@@ -27,7 +27,7 @@
                                     <div>Account Native ID: {{ acc.native_id }}</div>
                                     <div>Account is error: {{ acc.is_error }}</div>
                                     <div>Account DataLake: <a
-                                        href="{% url 'data_lake' company_id=company_id integration_id=integration.id account=acc.id %}">DataLake</a>
+                                        href="{% url 'data_lake' company_id=company.id integration_id=integration.id account=acc.id %}">DataLake</a>
                                     </div>
                                 </div>
                             {% endfor %}

--- a/demo/views.py
+++ b/demo/views.py
@@ -25,10 +25,9 @@ class CompanyInfo(TemplateView):
 
     def get_context_data(self, company_id: str, **kwargs):
         token = ConduitAPI.get_token(company_id)
-        credentials = ConduitCompanyAPI(token).get_credentials()
+        company = ConduitAPI().get_company(company_id, include_connections=True)
         return {
-            'company_id': company_id,
-            'credentials': credentials,
+            'company': company,
         }
 
 

--- a/demo/views.py
+++ b/demo/views.py
@@ -24,7 +24,6 @@ class CompanyInfo(TemplateView):
     template_name = 'company_info.html'
 
     def get_context_data(self, company_id: str, **kwargs):
-        token = ConduitAPI.get_token(company_id)
         company = ConduitAPI().get_company(company_id, include_connections=True)
         return {
             'company': company,


### PR DESCRIPTION
https://app.asana.com/0/1203033379433037/1203043029658851/f

на самом деле нашел только 1 штуку, которую надо было заменить - брать конекшены прямо из компании
а так, вот список используемых урлов

/link/company/{company_id}/
/link/company/
/link/credentials/connect/{integration_id}/
/link/data_lake/
ни один из них не deprecated